### PR TITLE
fixed lmfdbweb -> lmfdb

### DIFF
--- a/scripts/post-receive
+++ b/scripts/post-receive
@@ -4,7 +4,7 @@
 
 restart() {
     echo "updating $1" 
-    export GIT_WORK_TREE=/home/lmfdbweb/lmfdb-git-$1
+    export GIT_WORK_TREE=/home/lmfdb/lmfdb-git-$1
     git checkout $1 -f
     echo 'git HEAD now at' `git rev-parse HEAD`
     bash ~/restart-$1
@@ -16,7 +16,7 @@ do
     case $branch in
         prod) restart $branch
               ;;
-
+    
         beta) restart $branch
               ;;
     esac


### PR DESCRIPTION
Hello,

I'm fixing the mistake of having lmfdbweb instead of lmfdb.
I'm very confuse where did I get lmfdbweb... (we also use the user lmfdb)
Anyhow, the script is literally a copy paste from what you have on the server, with a typo fix from branc -> branch in the second line.
No need to link it, I just wanted to make it clear that this is the script that you are using to restart the servers when something changes.
Before you mentioned it, however there was no script.

Best,
Edgar
