### PR TITLE
new config for the replica set

### DIFF
--- a/config/mongod.conf
+++ b/config/mongod.conf
@@ -19,8 +19,8 @@ net:
   port: 37010
   bindIp: [127.0.0.1]
 #in the future:
-# bindIp: [127.0.0.1, 8.34.219.164, 104.154.18.133, 130.211.130.198, 104.197.135.84]
-# aka [localhost, m0.lmfdb.xyz, m1.lmfdb.xyz, arb.lmfdb.xyz, www.lmfdb.xyz]
+# bindIp: [127.0.0.1, 8.34.219.164, 104.154.18.133, 130.211.130.198, 146.148.66.176]
+# aka [localhost, m0.lmfdb.xyz, m1.lmfdb.xyz, warwick.lmfdb.xyz]
 
 
 processManagement:
@@ -30,11 +30,9 @@ processManagement:
 security:
  authorization: enabled 
 #needed for the replication
-# keyFile: /srv/mongodb/mongodb-keyfile
+ keyFile: /home/lmfdb/MONGODB_KEYFILE
 
 #operationProfiling:
 
-#replication:
-# replSetName: lmfdb0
-
-
+replication:
+ replSetName: lmfdb0


### PR DESCRIPTION
This is already on the server, no need to restart.

perhaps now we can also erase the old version on the server and replace them by the new ones after the pull, which should be identical (up to extra commented lines):

```
diff ~/warwick-nt-cluster/scripts/start-mongodb ~/start-mongodb
rm ~/start-mongodb ~/start-mongodb.old
ln -s ~/warwick-nt-cluster/scripts/start-mongodb ~/start-mongodb
diff ~/warwick-nt-cluster/config/mongod.conf ~/mongod.conf 
rm ~/mongod.conf
ln -s ~/warwick-nt-cluster/config/mongod.conf ~/mongod.conf 
```
