### PR TITLE
bindip fix

### DIFF
--- a/config/mongod.conf
+++ b/config/mongod.conf
@@ -17,11 +17,8 @@ systemLog:
 # network interfaces
 net:
   port: 37010
-  bindIp: [127.0.0.1]
-#in the future:
-# bindIp: [127.0.0.1, 8.34.219.164, 104.154.18.133, 130.211.130.198, 146.148.66.176]
-# aka [localhost, m0.lmfdb.xyz, m1.lmfdb.xyz, warwick.lmfdb.xyz]
-
+  bindIp: 0.0.0.0
+# warwick's firewall takes care of the rest
 
 processManagement:
  fork: true


### PR DESCRIPTION
this has not effect whatsoever, mongodb has been ignoring the bindIp argument, as it want's an array without the brackets
