### PR TITLE
Update mongod.conf

### DIFF
--- a/config/mongod.conf
+++ b/config/mongod.conf
@@ -5,6 +5,7 @@
 
 # Where and how to store data.
 storage:
+  engine: 'mmapv1'
   dbPath: /home/lmfdb/db
   journal:
     enabled: true
@@ -17,7 +18,7 @@ systemLog:
 # network interfaces
 net:
   port: 37010
-  bindIp: 0.0.0.0
+# mongodb listens on all ips by default
 # warwick's firewall takes care of the rest
 
 processManagement:


### PR DESCRIPTION
1- Takin care of the mongodb warning on start that informs us that it listens on all ips by default
2- Adding the line for the engine `engine: 'mmapv1'`, which is now implicit, but however this is needed for when we reindex the db.

Best,
Edgar
